### PR TITLE
Forward hooks are ignored when calling the forward method

### DIFF
--- a/nupic/torch/modules/sparse_weights.py
+++ b/nupic/torch/modules/sparse_weights.py
@@ -83,7 +83,7 @@ class SparseWeightsBase(nn.Module, metaclass=abc.ABCMeta):
     def forward(self, x):
         if self.training:
             self.rezero_weights()
-        return self.module.forward(x)
+        return self.module(x)
 
     @abc.abstractmethod
     def compute_indices(self):


### PR DESCRIPTION
Forward hooks are ignored when calling the forward method of the wrapped layer