### PR TITLE
Store a mask; Much smaller memory footprint

### DIFF
--- a/nupic/torch/compatibility.py
+++ b/nupic/torch/compatibility.py
@@ -1,0 +1,47 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2020, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+from collections import OrderedDict
+
+import torch
+
+
+def upgrade_to_masked_sparseweights(state_dict):
+    """
+    Returns a new state dict with any "zero_weights" tensors converted to
+    "zero_mask" tensors. (The "zero_weights" was a list of indices of zeroes in
+    the weight tensor.)
+    """
+    upgraded = []
+    for name, tensor in state_dict.items():
+        if "zero_weights" in name:
+            weight_name = name.replace("zero_weights", "module.weight")
+            zero_mask = torch.ones(state_dict[weight_name].shape,
+                                   device=tensor.device)
+            zero_idx = (tensor[0].long(), tensor[1].long())
+            zero_mask.view(zero_mask.shape[0], -1)[zero_idx] = 0.0
+
+            upgraded.append((name.replace("zero_weights", "zero_mask"),
+                             zero_mask))
+        else:
+            upgraded.append((name, tensor))
+
+    return OrderedDict(upgraded)

--- a/nupic/torch/models/sparse_cnn.py
+++ b/nupic/torch/models/sparse_cnn.py
@@ -320,8 +320,8 @@ class GSCSuperSparseCNN(GSCSparseCNN):
 
 
 MODEL_URLS = {
-    "gsc_sparse_cnn": "http://public.numenta.com/pytorch/hub/gsc_sparse_cnn-025f3331.pth",  # noqa: E501
-    "gsc_super_sparse_cnn": "http://public.numenta.com/pytorch/hub/gsc_super_sparse_cnn-08ce1fd2.pth",  # noqa: E501
+    "gsc_sparse_cnn": "http://public.numenta.com/pytorch/hub/gsc_sparse_cnn-7bc3782d.pth",  # noqa: E501
+    "gsc_super_sparse_cnn": "http://public.numenta.com/pytorch/hub/gsc_super_sparse_cnn-d412de15.pth",  # noqa: E501
 }
 
 

--- a/nupic/torch/models/sparse_cnn.py
+++ b/nupic/torch/models/sparse_cnn.py
@@ -320,8 +320,8 @@ class GSCSuperSparseCNN(GSCSparseCNN):
 
 
 MODEL_URLS = {
-    "gsc_sparse_cnn": "http://public.numenta.com/pytorch/hub/gsc_sparse_cnn-eac5f79f.pth",  # noqa: E501
-    "gsc_super_sparse_cnn": "http://public.numenta.com/pytorch/hub/gsc_super_sparse_cnn-b1e1921c.pth",  # noqa: E501
+    "gsc_sparse_cnn": "http://public.numenta.com/pytorch/hub/gsc_sparse_cnn-025f3331.pth",  # noqa: E501
+    "gsc_super_sparse_cnn": "http://public.numenta.com/pytorch/hub/gsc_super_sparse_cnn-08ce1fd2.pth",  # noqa: E501
 }
 
 

--- a/nupic/torch/modules/prunable_sparse_weights.py
+++ b/nupic/torch/modules/prunable_sparse_weights.py
@@ -19,7 +19,6 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
-import torch
 import torch.nn as nn
 
 from .sparse_weights import SparseWeights, SparseWeights2d
@@ -34,28 +33,21 @@ class PrunableSparseWeightBase(object):
     @property
     def off_mask(self):
         """
-        Accesses a boolean mask of size `self.weight.shape` which have non-zero
-        entries as defined by `zero_weights`. Thus one may call
+        Gets the value of `zero_mask` in bool format. Thus one may call
         ```
         self.weight[~self.off_mask]  # returns weights that are currently on
         ```
         """
-        out_shape = self.module.weight.shape[0]
-        zero_idx = (self.zero_weights[0].long(), self.zero_weights[1].long())
-        weight_mask = torch.zeros_like(self.module.weight).bool()
-        weight_mask.view(out_shape, -1)[zero_idx] = 1
-        return weight_mask
+        return self.zero_mask.bool()
 
     @off_mask.setter
     def off_mask(self, mask):
         """
-        Sets the values of `zero_weights` according to a mask of size
-        `self.weight.shape`.
+        Sets the values of `zero_mask`, updating self.sparsity to reflect the
+        sparsity of the new mask.
         """
-        mask = mask.bool()
         self.sparsity = mask.sum().item() / mask.numel()
-        out_shape = self.module.weight.shape[0]
-        self.zero_weights = mask.view(out_shape, -1).nonzero().permute(1, 0)
+        self.zero_mask[:] = mask
 
 
 class PrunableSparseWeights(SparseWeights, PrunableSparseWeightBase):
@@ -66,7 +58,7 @@ class PrunableSparseWeights(SparseWeights, PrunableSparseWeightBase):
     def __init__(self, module, weight_sparsity=None, sparsity=None):
         assert isinstance(module, nn.Linear)
         assert 0 <= (weight_sparsity or sparsity) <= 1
-        super(SparseWeights, self).__init__(
+        super().__init__(
             module, weight_sparsity=weight_sparsity, sparsity=sparsity
         )
 
@@ -80,6 +72,6 @@ class PrunableSparseWeights2d(SparseWeights2d, PrunableSparseWeightBase):
     def __init__(self, module, weight_sparsity=None, sparsity=None):
         assert isinstance(module, nn.Conv2d)
         assert 0 <= (weight_sparsity or sparsity) <= 1
-        super(SparseWeights2d, self).__init__(
+        super().__init__(
             module, weight_sparsity=weight_sparsity, sparsity=sparsity
         )

--- a/nupic/torch/modules/prunable_sparse_weights.py
+++ b/nupic/torch/modules/prunable_sparse_weights.py
@@ -19,8 +19,6 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
-import torch.nn as nn
-
 from .sparse_weights import SparseWeights, SparseWeights2d
 
 
@@ -56,10 +54,9 @@ class PrunableSparseWeights(SparseWeights, PrunableSparseWeightBase):
     changed dynamically through the `off_mask` property.
     """
     def __init__(self, module, weight_sparsity=None, sparsity=None):
-        assert isinstance(module, nn.Linear)
-        assert 0 <= (weight_sparsity or sparsity) <= 1
         super().__init__(
-            module, weight_sparsity=weight_sparsity, sparsity=sparsity
+            module, weight_sparsity=weight_sparsity, sparsity=sparsity,
+            allow_extremes=True
         )
 
 
@@ -70,8 +67,7 @@ class PrunableSparseWeights2d(SparseWeights2d, PrunableSparseWeightBase):
     """
 
     def __init__(self, module, weight_sparsity=None, sparsity=None):
-        assert isinstance(module, nn.Conv2d)
-        assert 0 <= (weight_sparsity or sparsity) <= 1
         super().__init__(
-            module, weight_sparsity=weight_sparsity, sparsity=sparsity
+            module, weight_sparsity=weight_sparsity, sparsity=sparsity,
+            allow_extremes=True
         )

--- a/nupic/torch/modules/sparse_weights.py
+++ b/nupic/torch/modules/sparse_weights.py
@@ -120,14 +120,24 @@ class SparseWeights(SparseWeightsBase):
       The module to sparsify the weights
     :param sparsity:
       Pct of weights that are zero in the layer.
+    :param allow_extremes:
+      Allow values sparsity=0 and sparsity=1. These values are often a sign that
+      there is a bug in the configuration, because they lead to Identity and
+      Zero layers, respectively, but they can make sense in scenarios where the
+      mask is dynamic.
     """
 
-    def __init__(self, module, weight_sparsity=None, sparsity=None):
+    def __init__(self, module, weight_sparsity=None, sparsity=None,
+                 allow_extremes=False):
         assert len(module.weight.shape) == 2, "Should resemble a nn.Linear"
-        assert 0 <= (weight_sparsity or sparsity) <= 1
         super(SparseWeights, self).__init__(
             module, weight_sparsity=weight_sparsity, sparsity=sparsity
         )
+
+        if allow_extremes:
+            assert 0 <= self.sparsity <= 1
+        else:
+            assert 0 < self.sparsity < 1
 
         # For each unit, decide which weights are going to be zero
         in_features = self.module.in_features
@@ -156,14 +166,24 @@ class SparseWeights2d(SparseWeightsBase):
       The module to sparsify the weights
     :param sparsity:
       Pct of weights that are zero in the layer.
+    :param allow_extremes:
+      Allow values sparsity=0 and sparsity=1. These values are often a sign that
+      there is a bug in the configuration, because they lead to Identity and
+      Zero layers, respectively, but they can make sense in scenarios where the
+      mask is dynamic.
     """
 
-    def __init__(self, module, weight_sparsity=None, sparsity=None):
+    def __init__(self, module, weight_sparsity=None, sparsity=None,
+                 allow_extremes=False):
         assert len(module.weight.shape) == 4, "Should resemble a nn.Conv2d"
-        assert 0 <= (weight_sparsity or sparsity) <= 1
         super(SparseWeights2d, self).__init__(
             module, weight_sparsity=weight_sparsity, sparsity=sparsity
         )
+
+        if allow_extremes:
+            assert 0 <= self.sparsity <= 1
+        else:
+            assert 0 < self.sparsity < 1
 
         # For each unit, decide which weights are going to be zero
         in_channels = self.module.in_channels

--- a/nupic/torch/modules/sparse_weights.py
+++ b/nupic/torch/modules/sparse_weights.py
@@ -81,8 +81,6 @@ class SparseWeightsBase(nn.Module, metaclass=abc.ABCMeta):
 
         self.module = module
         self.sparsity = sparsity
-        self.register_buffer("zero_weights", self.compute_indices())
-        self.rezero_weights()
 
     def extra_repr(self):
         return "sparsity={}".format(self.sparsity)
@@ -101,19 +99,8 @@ class SparseWeightsBase(nn.Module, metaclass=abc.ABCMeta):
         return 1.0 - self.sparsity
 
     @abc.abstractmethod
-    def compute_indices(self):
-        """For each unit, decide which weights are going to be zero.
-
-        :return: tensor indices for all non-zero weights. See :meth:`rezeroWeights`
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
     def rezero_weights(self):
-        """Set the previously selected weights to zero.
-
-        See :meth:`computeIndices`
-        """
+        """Set the previously selected weights to zero."""
         raise NotImplementedError
 
     @property
@@ -136,33 +123,27 @@ class SparseWeights(SparseWeightsBase):
     """
 
     def __init__(self, module, weight_sparsity=None, sparsity=None):
-        assert isinstance(module, nn.Linear)
-        assert 0 < (weight_sparsity or sparsity) < 1
+        assert len(module.weight.shape) == 2, "Should resemble a nn.Linear"
+        assert 0 <= (weight_sparsity or sparsity) <= 1
         super(SparseWeights, self).__init__(
             module, weight_sparsity=weight_sparsity, sparsity=sparsity
         )
 
-    def compute_indices(self):
         # For each unit, decide which weights are going to be zero
-        output_size, input_size = self.module.weight.shape
-        num_zeros = int(round(self.sparsity * input_size))
+        in_features = self.module.in_features
+        out_features = self.module.out_features
+        num_nz = int(round((1 - self.sparsity) * in_features))
+        zero_mask = torch.ones(out_features, in_features, dtype=torch.bool)
+        for out_feature in range(out_features):
+            in_indices = np.random.choice(in_features, num_nz, replace=False)
+            zero_mask[out_feature, in_indices] = False
+        # Use float16 because pytorch distributed nccl doesn't support bools
+        self.register_buffer("zero_mask", zero_mask.half())
 
-        output_indices = np.arange(output_size)
-        input_indices = np.array(
-            [np.random.permutation(input_size)[:num_zeros] for _ in output_indices],
-            dtype=np.long,
-        )
-
-        # Create tensor indices for all non-zero weights
-        zero_indices = np.empty((output_size, num_zeros, 2), dtype=np.long)
-        zero_indices[:, :, 0] = output_indices[:, None]
-        zero_indices[:, :, 1] = input_indices
-        zero_indices = zero_indices.reshape(-1, 2)
-        return torch.from_numpy(zero_indices.transpose())
+        self.rezero_weights()
 
     def rezero_weights(self):
-        zero_idx = (self.zero_weights[0].long(), self.zero_weights[1].long())
-        self.module.weight.data[zero_idx] = 0.0
+        self.module.weight.data[self.zero_mask.bool()] = 0
 
 
 class SparseWeights2d(SparseWeightsBase):
@@ -178,35 +159,28 @@ class SparseWeights2d(SparseWeightsBase):
     """
 
     def __init__(self, module, weight_sparsity=None, sparsity=None):
-        assert isinstance(module, nn.Conv2d)
-        assert 0 < (weight_sparsity or sparsity) < 1
+        assert len(module.weight.shape) == 4, "Should resemble a nn.Conv2d"
+        assert 0 <= (weight_sparsity or sparsity) <= 1
         super(SparseWeights2d, self).__init__(
             module, weight_sparsity=weight_sparsity, sparsity=sparsity
         )
 
-    def compute_indices(self):
         # For each unit, decide which weights are going to be zero
         in_channels = self.module.in_channels
         out_channels = self.module.out_channels
         kernel_size = self.module.kernel_size
 
         input_size = in_channels * kernel_size[0] * kernel_size[1]
-        num_zeros = int(round(self.sparsity * input_size))
+        num_nz = int(round((1 - self.sparsity) * input_size))
+        zero_mask = torch.ones(out_channels, input_size, dtype=torch.bool)
+        for out_channel in range(out_channels):
+            in_indices = np.random.choice(input_size, num_nz, replace=False)
+            zero_mask[out_channel, in_indices] = False
+        zero_mask = zero_mask.view(out_channels, in_channels, *kernel_size)
+        # Use float16 because pytorch distributed nccl doesn't support bools
+        self.register_buffer("zero_mask", zero_mask.half())
 
-        output_indices = np.arange(out_channels)
-        input_indices = np.array(
-            [np.random.permutation(input_size)[:num_zeros] for _ in output_indices],
-            dtype=np.long,
-        )
-
-        # Create tensor indices for all non-zero weights
-        zero_indices = np.empty((out_channels, num_zeros, 2), dtype=np.long)
-        zero_indices[:, :, 0] = output_indices[:, None]
-        zero_indices[:, :, 1] = input_indices
-        zero_indices = zero_indices.reshape(-1, 2)
-
-        return torch.from_numpy(zero_indices.transpose())
+        self.rezero_weights()
 
     def rezero_weights(self):
-        zero_idx = (self.zero_weights[0].long(), self.zero_weights[1].long())
-        self.module.weight.data.view(self.module.out_channels, -1)[zero_idx] = 0.0
+        self.module.weight.data[self.zero_mask.bool()] = 0

--- a/tests/sparse_weights_test.py
+++ b/tests/sparse_weights_test.py
@@ -113,7 +113,7 @@ class TestSparseWeights(unittest.TestCase):
         self.assertTrue(torch.all(sw.off_mask == torch.zeros_like(sw.weight)))
         sw.weight[:] = 1
         sw.rezero_weights()
-        self.assertTrue(sw.weight.sum() == sw.weight.numel())
+        self.assertEqual(sw.weight.sum(), sw.weight.numel())
 
     def test_prunable_sparse_linear(self):
 
@@ -123,7 +123,7 @@ class TestSparseWeights(unittest.TestCase):
         self.assertTrue(torch.all(sw.off_mask == torch.ones_like(sw.weight)))
         sw.weight[:] = 1
         sw.rezero_weights()
-        self.assertTrue(sw.weight.sum() == 0)
+        self.assertEqual(sw.weight.sum(), 0)
 
     def test_prunable_dense_conv(self):
 
@@ -133,7 +133,7 @@ class TestSparseWeights(unittest.TestCase):
         self.assertTrue(torch.all(sw.off_mask == torch.zeros_like(sw.weight)))
         sw.weight[:] = 1
         sw.rezero_weights()
-        self.assertTrue(sw.weight.sum() == sw.weight.numel())
+        self.assertEqual(sw.weight.sum(), sw.weight.numel())
 
     def test_prunable_sparse_conv(self):
 
@@ -143,7 +143,7 @@ class TestSparseWeights(unittest.TestCase):
         self.assertTrue(torch.all(sw.off_mask == torch.ones_like(sw.weight)))
         sw.weight[:] = 1
         sw.rezero_weights()
-        self.assertTrue(sw.weight.sum() == 0)
+        self.assertEqual(sw.weight.sum(), 0)
 
     def test_linear_prunable_off_mask(self):
 
@@ -156,10 +156,10 @@ class TestSparseWeights(unittest.TestCase):
             [1, 1, 0, 0],
             [0, 0, 0, 0]
         ])
-        self.assertTrue(sw.sparsity == 6 / 16)
+        self.assertEqual(sw.sparsity, 6 / 16)
         sw.weight[:] = 1
         sw.rezero_weights()
-        self.assertTrue(sw.weight.sum() == 10)
+        self.assertEqual(sw.weight.sum(), 10)
 
     def test_conv_prunable_off_mask(self):
 
@@ -172,10 +172,10 @@ class TestSparseWeights(unittest.TestCase):
             [1, 1, 0, 0],
             [0, 0, 0, 0]
         ]).view(2, 2, 2, 2)
-        self.assertTrue(sw.sparsity == 6 / 16)
+        self.assertEqual(sw.sparsity, 6 / 16)
         sw.weight[:] = 1
         sw.rezero_weights()
-        self.assertTrue(sw.weight.sum() == 10)
+        self.assertEqual(sw.weight.sum(), 10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Rather than storing a list of zero indices, store a zero mask.

With this change, the SparseWeightsBase no longer prescribes how the zeroes should be stored; the subclass gets to decide this. This enables subclasses to choose more efficient case-specific rezeroing techniques, for example when sparsity is structured (e.g. channel-to-channel).

**Memory usage of resnet50, before and after:**

Before:
- 672,979,068 bytes total
- 570,523,648 bytes of SparseWeights zero indices

After:
- 152,778,876 bytes total
- 50,323,456 bytes of SparseWeights masks

And the memory improvement gets considerably better if the sparsity is structured (e.g. channel to channel), enabling broadcasting.