### PR TITLE
Move rezero_weights from post_epoch to post_batch

### DIFF
--- a/examples/gsc/run_gsc_model.py
+++ b/examples/gsc/run_gsc_model.py
@@ -73,7 +73,7 @@ DATAPATH = Path("data")
 EXTRACTPATH = DATAPATH / "raw"
 
 
-def train(model, loader, optimizer, criterion, device):
+def train(model, loader, optimizer, criterion, device, post_batch_callback=None):
     """
     Train the model using given dataset loader.
     Called on every epoch.
@@ -88,6 +88,8 @@ def train(model, loader, optimizer, criterion, device):
     :type criterion: function
     :param device:
     :type device: :class:`torch.device`
+    :param post_batch_callback: function(model) to call after every batch
+    :type post_batch_callback: function
     """
     model.train()
     for data, target in tqdm(loader, desc="Train", leave=False):
@@ -97,6 +99,8 @@ def train(model, loader, optimizer, criterion, device):
         loss = criterion(output, target)
         loss.backward()
         optimizer.step()
+        if post_batch_callback is not None:
+            post_batch_callback(model)
 
 
 def test(model, loader, criterion, device, desc="Test"):
@@ -132,6 +136,10 @@ def test(model, loader, criterion, device, desc="Test"):
     return {"accuracy": total_correct / len(loader.dataset),
             "loss": loss / len(loader.dataset),
             "total_correct": total_correct}
+
+
+def post_batch(model):
+    model.apply(rezero_weights)
 
 
 def do_training(model, device):
@@ -194,9 +202,8 @@ def do_training(model, device):
 
         model.apply(update_boost_strength)
         train(model=model, loader=train_loader, optimizer=sgd,
-              criterion=F.nll_loss, device=device)
+              criterion=F.nll_loss, device=device, post_batch_callback=post_batch)
         lr_scheduler.step()
-        model.apply(rezero_weights)
 
         results = test(model=model, loader=valid_loader, criterion=F.nll_loss,
                        device=device)

--- a/examples/sparse_cnn.ipynb
+++ b/examples/sparse_cnn.ipynb
@@ -87,7 +87,7 @@
     "        return image\n",
     "\n",
     "\n",
-    "def train(model, loader, optimizer, criterion):\n",
+    "def train(model, loader, optimizer, criterion, post_batch_callback=None):\n",
     "    \"\"\"\n",
     "    Train the model using given dataset loader. \n",
     "    Called on every epoch.\n",
@@ -99,6 +99,8 @@
     "    :type optimizer: :class:`torch.optim.Optimizer`\n",
     "    :param criterion: loss function to use\n",
     "    :type criterion: function\n",
+    "    :param post_batch_callback: function(model) to call after every batch\n",
+    "    :type post_batch_callback: function\n",
     "    \"\"\"\n",
     "    model.train()\n",
     "    for batch_idx, (data, target) in enumerate(tqdm(loader, leave=False)):\n",
@@ -108,6 +110,9 @@
     "        loss = criterion(output, target)\n",
     "        loss.backward()\n",
     "        optimizer.step()\n",
+    "        if post_batch_callback is not None:\n",
+    "            post_batch_callback(model)\n",
+    "        \n",
     "\n",
     "\n",
     "def test(model, loader, criterion):\n",
@@ -251,7 +256,7 @@
    "metadata": {},
    "source": [
     "### Train\n",
-    "On the first epoch we use smaller batch size to calculate the duty cycles used by the k-winner function. Once the duty cycles stabilize we can use larger batch sizes."
+    "On the first epoch we use smaller batch size to calculate the duty cycles used by the k-winner function. Once the duty cycles stabilize we can use larger batch sizes. Using the `post_batch`, we rezero the weights after every batch to keep the initial sparsity constant."
    ]
   },
   {
@@ -282,15 +287,18 @@
     }
    ],
    "source": [
+    "def post_batch(model):\n",
+    "    model.apply(rezero_weights)\n",
+    "\n",
     "sgd = optim.SGD(sparse_cnn.parameters(), lr=LEARNING_RATE, momentum=MOMENTUM)\n",
-    "train(model=sparse_cnn, loader=first_loader, optimizer=sgd, criterion=F.nll_loss)"
+    "train(model=sparse_cnn, loader=first_loader, optimizer=sgd, criterion=F.nll_loss, post_batch_callback=post_batch)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After each epoch we rezero the weights to keep the initial sparsity constant during training. We also apply the boost strength factor after each epoch"
+    "After each epoch we apply the boost strength factor"
    ]
   },
   {
@@ -300,7 +308,6 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "sparse_cnn.apply(rezero_weights)\n",
     "sparse_cnn.apply(update_boost_strength)"
    ]
   },
@@ -754,8 +761,7 @@
    ],
    "source": [
     "for epoch in range(1, EPOCHS):\n",
-    "    train(model=sparse_cnn, loader=train_loader, optimizer=sgd, criterion=F.nll_loss)\n",
-    "    sparse_cnn.apply(rezero_weights)\n",
+    "    train(model=sparse_cnn, loader=train_loader, optimizer=sgd, criterion=F.nll_loss, post_batch_callback=post_batch)\n",
     "    sparse_cnn.apply(update_boost_strength)\n",
     "    results = test(model=sparse_cnn, loader=test_loader, criterion=F.nll_loss)\n",
     "    print(results)"

--- a/examples/sparse_linear.ipynb
+++ b/examples/sparse_linear.ipynb
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,7 +89,7 @@
     "        a[noise] = self.white_value\n",
     "        return image\n",
     "\n",
-    "def train(model, loader, optimizer, criterion):\n",
+    "def train(model, loader, optimizer, criterion, post_batch_callback=None):\n",
     "    \"\"\"\n",
     "    Train the model using given dataset loader. \n",
     "    Called on every epoch.\n",
@@ -101,6 +101,8 @@
     "    :type optimizer: :class:`torch.optim.Optimizer`\n",
     "    :param criterion: loss function to use\n",
     "    :type criterion: function\n",
+    "    :param post_batch_callback: function(model) to call after every batch\n",
+    "    :type post_batch_callback: function\n",
     "    \"\"\"\n",
     "    model.train()\n",
     "    for batch_idx, (data, target) in enumerate(tqdm(loader, leave=False)):\n",
@@ -110,6 +112,8 @@
     "        loss = criterion(output, target)\n",
     "        loss.backward()\n",
     "        optimizer.step()\n",
+    "        if post_batch_callback is not None:\n",
+    "            post_batch_callback(model)\n",
     "\n",
     "\n",
     "def test(model, loader, criterion):\n",
@@ -240,7 +244,7 @@
    "metadata": {},
    "source": [
     "### Train\n",
-    "On the first epoch we use smaller batch size to calculate the duty cycles used by the k-winner function. Once the duty cycles stabilize we can use larger batch sizes."
+    "On the first epoch we use smaller batch size to calculate the duty cycles used by the k-winner function. Once the duty cycles stabilize we can use larger batch sizes. Using the `post_batch`, we rezero the weights after every batch to keep the initial sparsity constant."
    ]
   },
   {
@@ -271,15 +275,18 @@
     }
    ],
    "source": [
+    "def post_batch(model):\n",
+    "    model.apply(rezero_weights)\n",
+    "\n",
     "sgd = optim.SGD(sparse_nn.parameters(), lr=LEARNING_RATE, momentum=MOMENTUM)\n",
-    "train(model=sparse_nn, loader=first_loader, optimizer=sgd, criterion=F.nll_loss)"
+    "train(model=sparse_nn, loader=first_loader, optimizer=sgd, criterion=F.nll_loss, post_batch_callback=post_batch)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After each epoch we rezero the weights to keep the initial sparsity constant during training. We also apply the boost strength factor after each epoch"
+    "After each epoch apply the boost strength factor"
    ]
   },
   {
@@ -289,7 +296,6 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "sparse_nn.apply(rezero_weights)\n",
     "sparse_nn.apply(update_boost_strength)"
    ]
   },
@@ -743,8 +749,7 @@
    ],
    "source": [
     "for epoch in range(1, EPOCHS):\n",
-    "    train(model=sparse_nn, loader=train_loader, optimizer=sgd, criterion=F.nll_loss)\n",
-    "    sparse_nn.apply(rezero_weights)\n",
+    "    train(model=sparse_nn, loader=train_loader, optimizer=sgd, criterion=F.nll_loss, post_batch_callback=post_batch)\n",
     "    sparse_nn.apply(update_boost_strength)\n",
     "    results = test(model=sparse_nn, loader=test_loader, criterion=F.nll_loss)\n",
     "    print(results)"

--- a/examples/sparse_mnist.ipynb
+++ b/examples/sparse_mnist.ipynb
@@ -68,7 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def train(model, loader, optimizer, criterion):\n",
+    "def train(model, loader, optimizer, criterion, post_batch_callback=None):\n",
     "    \"\"\"\n",
     "    Train the model using given dataset loader. \n",
     "    Called on every epoch.\n",
@@ -80,6 +80,8 @@
     "    :type optimizer: :class:`torch.optim.Optimizer`\n",
     "    :param criterion: loss function to use\n",
     "    :type criterion: function\n",
+    "    :param post_batch_callback: function(model) to call after every batch\n",
+    "    :type post_batch_callback: function\n",
     "    \"\"\"\n",
     "    model.train()\n",
     "    for batch_idx, (data, target) in enumerate(tqdm(loader, leave=False)):\n",
@@ -89,6 +91,8 @@
     "        loss = criterion(output, target)\n",
     "        loss.backward()\n",
     "        optimizer.step()\n",
+    "        if post_batch_callback is not None:\n",
+    "            post_batch_callback(model)\n",
     "\n",
     "\n",
     "def test(model, loader, criterion):\n",
@@ -223,7 +227,7 @@
    "metadata": {},
    "source": [
     "### Train\n",
-    "On the first epoch we use smaller batch size to calculate the duty cycles used by the k-winner function. Once the duty cycles stabilize we can use larger batch sizes."
+    "On the first epoch we use smaller batch size to calculate the duty cycles used by the k-winner function. Once the duty cycles stabilize we can use larger batch sizes. Using the `post_batch`, we rezero the weights after every batch to keep the initial sparsity constant."
    ]
   },
   {
@@ -240,9 +244,14 @@
     }
    ],
    "source": [
+    "from nupic.torch.modules import rezero_weights, update_boost_strength\n",
+    "\n",
+    "def post_batch(model):\n",
+    "    model.apply(rezero_weights)\n",
+    "\n",
     "sgd = optim.SGD(model.parameters(), lr=LEARNING_RATE, momentum=MOMENTUM)\n",
     "lr_scheduler = optim.lr_scheduler.StepLR(sgd, step_size=1, gamma=LEARNING_RATE_GAMMA)\n",
-    "train(model=model, loader=first_loader, optimizer=sgd, criterion=F.nll_loss)\n",
+    "train(model=model, loader=first_loader, optimizer=sgd, criterion=F.nll_loss, post_batch_callback=post_batch)\n",
     "lr_scheduler.step()"
    ]
   },
@@ -250,7 +259,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After each epoch we rezero the weights to keep the initial sparsity constant during training. We also apply the boost strength factor after each epoch"
+    "After each we apply the boost strength factor"
    ]
   },
   {
@@ -260,8 +269,6 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "from nupic.torch.modules import rezero_weights, update_boost_strength\n",
-    "model.apply(rezero_weights)\n",
     "model.apply(update_boost_strength)"
    ]
   },
@@ -334,7 +341,7 @@
    ],
    "source": [
     "for epoch in range(1, EPOCHS):\n",
-    "    train(model=model, loader=train_loader, optimizer=sgd, criterion=F.nll_loss)\n",
+    "    train(model=model, loader=train_loader, optimizer=sgd, criterion=F.nll_loss, post_batch_callback=post_batch)\n",
     "    lr_scheduler.step()\n",
     "    model.apply(rezero_weights)\n",
     "    model.apply(update_boost_strength)\n",

--- a/nupic/torch/modules/sparse_weights.py
+++ b/nupic/torch/modules/sparse_weights.py
@@ -88,8 +88,6 @@ class SparseWeightsBase(nn.Module, metaclass=abc.ABCMeta):
         return "sparsity={}".format(self.sparsity)
 
     def forward(self, x):
-        if self.training:
-            self.rezero_weights()
         return self.module(x)
 
     @property

--- a/tests/sparse_weights_test.py
+++ b/tests/sparse_weights_test.py
@@ -63,7 +63,7 @@ class TestSparseWeights(unittest.TestCase):
                 expected = [round(input_size * (1.0 - sparsity))] * out_channels
                 self.assertSequenceEqual(counts.numpy().tolist(), expected)
 
-    def test_rezero_after_forward_1d(self):
+    def test_rezero_1d(self):
         in_features, out_features = 784, 10
         for sparsity in [0.1, 0.5, 0.9]:
             linear = torch.nn.Linear(in_features=in_features,
@@ -72,9 +72,6 @@ class TestSparseWeights(unittest.TestCase):
 
             # Ensure weights are not sparse
             sparse.module.weight.data.fill_(1.0)
-            sparse.train()
-            x = torch.ones((1,) + (in_features,))
-            sparse(x)
 
             # Rezero, verify the weights become sparse
             sparse.rezero_weights()
@@ -83,7 +80,7 @@ class TestSparseWeights(unittest.TestCase):
             expected = [round(in_features * (1.0 - sparsity))] * out_features
             self.assertSequenceEqual(counts.numpy().tolist(), expected)
 
-    def test_rezero_after_forward_2d(self):
+    def test_rezero_2d(self):
         in_channels, kernel_size, out_channels = 64, (5, 5), 64
         input_size = in_channels * kernel_size[0] * kernel_size[1]
 
@@ -96,9 +93,6 @@ class TestSparseWeights(unittest.TestCase):
 
                 # Ensure weights are not sparse
                 sparse.module.weight.data.fill_(1.0)
-                sparse.train()
-                x = torch.ones((1,) + (in_channels, kernel_size[0], kernel_size[1]))
-                sparse(x)
 
                 # Rezero, verify the weights become sparse
                 sparse.rezero_weights()

--- a/tests/sparse_weights_test.py
+++ b/tests/sparse_weights_test.py
@@ -76,7 +76,8 @@ class TestSparseWeights(unittest.TestCase):
             x = torch.ones((1,) + (in_features,))
             sparse(x)
 
-            # When training, the forward function should set weights back to zero.
+            # Rezero, verify the weights become sparse
+            sparse.rezero_weights()
             nonzeros = torch.nonzero(sparse.module.weight, as_tuple=True)[0]
             counts = torch.unique(nonzeros, return_counts=True)[1]
             expected = [round(in_features * (1.0 - sparsity))] * out_features
@@ -99,7 +100,8 @@ class TestSparseWeights(unittest.TestCase):
                 x = torch.ones((1,) + (in_channels, kernel_size[0], kernel_size[1]))
                 sparse(x)
 
-                # When training, the forward function should set weights back to zero.
+                # Rezero, verify the weights become sparse
+                sparse.rezero_weights()
                 nonzeros = torch.nonzero(sparse.module.weight, as_tuple=True)[0]
                 counts = torch.unique(nonzeros, return_counts=True)[1]
                 expected = [round(input_size * (1.0 - sparsity))] * out_channels


### PR DESCRIPTION
This change removes the rezero_weights from the forward pass. This makes the code more readable (currently our experiment code looks like it only rezeroes once per epoch) and less error-prone (currently we can't run validation mid-epoch, we have to remember to insert another rezero). It is much simpler to rezero in exactly one place: post-batch.