### PR TITLE
KWinners perf: break_ties, relu, and inplace

### DIFF
--- a/nupic/torch/functions/__init__.py
+++ b/nupic/torch/functions/__init__.py
@@ -19,5 +19,10 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 from .k_winners import (
-    KWinners2dGlobal, KWinners2dLocal, KWinners
+    KWinners2dGlobal,
+    KWinners2dLocal,
+    KWinners,
+    kwinners_2d_global_no_tiebreak,
+    kwinners_2d_local_no_tiebreak,
+    kwinners_no_tiebreak,
 )

--- a/nupic/torch/functions/__init__.py
+++ b/nupic/torch/functions/__init__.py
@@ -18,11 +18,4 @@
 #
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
-from .k_winners import (
-    KWinners2dGlobal,
-    KWinners2dLocal,
-    KWinners,
-    kwinners_2d_global_no_tiebreak,
-    kwinners_2d_local_no_tiebreak,
-    kwinners_no_tiebreak,
-)
+from .k_winners import *

--- a/nupic/torch/functions/k_winners.py
+++ b/nupic/torch/functions/k_winners.py
@@ -21,7 +21,7 @@
 import torch
 
 
-def kwinners(x, duty_cycles, k, boost_strength, break_ties=True, relu=False,
+def kwinners(x, duty_cycles, k, boost_strength, break_ties=False, relu=False,
              inplace=False):
     """
     A simple K-winner take all function for creating layers with sparse output.
@@ -115,7 +115,7 @@ def kwinners(x, duty_cycles, k, boost_strength, break_ties=True, relu=False,
         return x.masked_fill(off_mask, 0)
 
 
-def kwinners2d(x, duty_cycles, k, boost_strength, local=True, break_ties=True,
+def kwinners2d(x, duty_cycles, k, boost_strength, local=True, break_ties=False,
                relu=False, inplace=False):
     """
     A K-winner take all function for creating Conv2d layers with sparse output.

--- a/nupic/torch/functions/k_winners.py
+++ b/nupic/torch/functions/k_winners.py
@@ -201,7 +201,7 @@ def kwinners2d(x, duty_cycles, k, boost_strength, local=True, break_ties=True,
 
 def boost_activations(x, duty_cycles, boost_strength):
     """
-    Boosting normally would compute
+    Boosting as documented in :meth:`kwinners` would compute
       x * torch.exp((target_density - duty_cycles) * boost_strength)
     but instead we compute
       x * torch.exp(-boost_strength * duty_cycles)

--- a/nupic/torch/modules/k_winners.py
+++ b/nupic/torch/modules/k_winners.py
@@ -200,7 +200,7 @@ class KWinners(KWinnersBase):
         boost_strength=1.0,
         boost_strength_factor=0.9,
         duty_cycle_period=1000,
-        break_ties=True,
+        break_ties=False,
         relu=False,
         inplace=False,
     ):
@@ -315,7 +315,7 @@ class KWinners2d(KWinnersBase):
         boost_strength_factor=0.9,
         duty_cycle_period=1000,
         local=False,
-        break_ties=True,
+        break_ties=False,
         relu=False,
         inplace=False,
     ):

--- a/tests/k_winners2d_global_test.py
+++ b/tests/k_winners2d_global_test.py
@@ -26,14 +26,6 @@ import nupic.torch.functions as F
 from nupic.torch.modules import KWinners2d
 
 
-class LocalTestContext(object):
-    def __init__(self):
-        self.saved_tensors = None
-
-    def save_for_backward(self, x):
-        self.saved_tensors = (x,)
-
-
 class KWinners2DTest(unittest.TestCase):
     """"""
 
@@ -47,7 +39,6 @@ class KWinners2DTest(unittest.TestCase):
         x[0, 1, 0, 1] = 1.21
         x[0, 2, 1, 0] = 1.30
         self.x = x
-        self.gradient = torch.rand(x.shape)
 
         # Batch size 2
         x = torch.rand(2, 3, 2, 2) / 2.0
@@ -71,87 +62,46 @@ class KWinners2DTest(unittest.TestCase):
         """Equal duty cycle, boost factor 0, k=4, batch size 1."""
         x = self.x
 
-        ctx = LocalTestContext()
-
-        result = F.KWinners2dGlobal.forward(ctx, x, self.duty_cycle, k=4,
-                                            boost_strength=0.0)
-
         expected = torch.zeros_like(x)
         expected[0, 0, 1, 0] = x[0, 0, 1, 0]
         expected[0, 0, 1, 1] = x[0, 0, 1, 1]
         expected[0, 1, 0, 1] = x[0, 1, 0, 1]
         expected[0, 2, 1, 0] = x[0, 2, 1, 0]
 
-        self.assertEqual(result.shape, expected.shape)
+        for break_ties in [True, False]:
+            with self.subTest(break_ties=break_ties):
+                result = F.kwinners2d(x, self.duty_cycle, k=4,
+                                      boost_strength=0.0, local=False,
+                                      break_ties=break_ties)
 
-        num_correct = (result == expected).sum()
-        self.assertEqual(num_correct, result.reshape(-1).size()[0])
+                self.assertEqual(result.shape, expected.shape)
 
-        indices = ctx.saved_tensors[0].reshape(-1).sort()[0]
-        expected_indices = torch.tensor([2, 3, 5, 10])
-        num_correct = (indices == expected_indices).sum()
-        self.assertEqual(num_correct, 4)
-
-        # Test that gradient values are in the right places, that their sum is
-        # equal, and that they have exactly the right number of nonzeros
-        grad_x, _, _, _ = F.KWinners2dGlobal.backward(ctx, self.gradient)
-        grad_x = grad_x.reshape(-1)
-        self.assertEqual(
-            (grad_x[indices] == self.gradient.reshape(-1)[indices]).sum(), 4
-        )
-        self.assertAlmostEqual(
-            grad_x.sum().item(),
-            self.gradient.reshape(-1)[indices].sum().item(),
-            places=4,
-        )
-        self.assertEqual(len(grad_x.nonzero()), 4)
+                num_correct = (result == expected).sum()
+                self.assertEqual(num_correct, result.reshape(-1).size()[0])
 
     def test_two(self):
         """Equal duty cycle, boost factor 0, k=3."""
         x = self.x
-
-        ctx = LocalTestContext()
-
-        result = F.KWinners2dGlobal.forward(ctx, x, self.duty_cycle, k=3,
-                                            boost_strength=0.0)
 
         expected = torch.zeros_like(x)
         expected[0, 0, 1, 1] = x[0, 0, 1, 1]
         expected[0, 1, 0, 1] = x[0, 1, 0, 1]
         expected[0, 2, 1, 0] = x[0, 2, 1, 0]
 
-        self.assertEqual(result.shape, expected.shape)
+        for break_ties in [True, False]:
+            with self.subTest(break_ties=break_ties):
+                result = F.kwinners2d(x, self.duty_cycle, k=3,
+                                      boost_strength=0.0, local=False,
+                                      break_ties=break_ties)
 
-        num_correct = (result == expected).sum()
-        self.assertEqual(num_correct, result.reshape(-1).size()[0])
+                self.assertEqual(result.shape, expected.shape)
 
-        indices = ctx.saved_tensors[0].reshape(-1).sort()[0]
-        expected_indices = torch.tensor([3, 5, 10])
-        num_correct = (indices == expected_indices).sum()
-        self.assertEqual(num_correct, 3)
-
-        # Test that gradient values are in the right places, that their sum is
-        # equal, and that they have exactly the right number of nonzeros
-        grad_x, _, _, _ = F.KWinners2dGlobal.backward(ctx, self.gradient)
-        grad_x = grad_x.reshape(-1)
-        self.assertEqual(
-            (grad_x[indices] == self.gradient.reshape(-1)[indices]).sum(), 3
-        )
-        self.assertAlmostEqual(
-            grad_x.sum().item(),
-            self.gradient.reshape(-1)[indices].sum().item(),
-            places=4,
-        )
-        self.assertEqual(len(grad_x.nonzero()), 3)
+                num_correct = (result == expected).sum()
+                self.assertEqual(num_correct, result.reshape(-1).size()[0])
 
     def test_three(self):
         """Equal duty cycle, boost factor=0, k=4, batch size=2."""
         x = self.x2
-
-        ctx = LocalTestContext()
-
-        result = F.KWinners2dGlobal.forward(ctx, x, self.duty_cycle, k=4,
-                                            boost_strength=0.0)
 
         expected = torch.zeros_like(x)
         expected[0, 0, 1, 0] = x[0, 0, 1, 0]
@@ -163,32 +113,19 @@ class KWinners2DTest(unittest.TestCase):
         expected[1, 1, 0, 1] = x[1, 1, 0, 1]
         expected[1, 2, 1, 1] = x[1, 2, 1, 1]
 
-        self.assertEqual(result.shape, expected.shape)
+        for break_ties in [True, False]:
+            with self.subTest(break_ties=break_ties):
+                result = F.kwinners2d(x, self.duty_cycle, k=4,
+                                      boost_strength=0.0, local=False,
+                                      break_ties=break_ties)
+                self.assertEqual(result.shape, expected.shape)
 
-        num_correct = (result == expected).sum()
-        self.assertEqual(num_correct, result.reshape(-1).size()[0])
-
-        indices = ctx.saved_tensors[0].sort()[0]
-        expected_indices = torch.tensor([[2, 3, 5, 10], [0, 4, 5, 11]])
-        num_correct = (indices == expected_indices).sum()
-        self.assertEqual(num_correct, 8)
-
-        # Test that gradient values are in the right places, that their sum is
-        # equal, and that they have exactly the right number of nonzeros
-        out_grad, _, _, _ = F.KWinners2dGlobal.backward(ctx, self.gradient2)
-        out_grad = out_grad.reshape(2, -1)
-        in_grad = self.gradient2.reshape(2, -1)
-        self.assertEqual((out_grad == in_grad).sum(), 8)
-        self.assertEqual(len(out_grad.nonzero()), 8)
+                num_correct = (result == expected).sum()
+                self.assertEqual(num_correct, result.reshape(-1).size()[0])
 
     def test_four(self):
         """Equal duty cycle, boost factor=0, k=3, batch size=2."""
         x = self.x2
-
-        ctx = LocalTestContext()
-
-        result = F.KWinners2dGlobal.forward(ctx, x, self.duty_cycle, k=3,
-                                            boost_strength=0.0)
 
         expected = torch.zeros_like(x)
         expected[0, 0, 1, 1] = x[0, 0, 1, 1]
@@ -198,23 +135,16 @@ class KWinners2DTest(unittest.TestCase):
         expected[1, 1, 0, 1] = x[1, 1, 0, 1]
         expected[1, 2, 1, 1] = x[1, 2, 1, 1]
 
-        self.assertEqual(result.shape, expected.shape)
+        for break_ties in [True, False]:
+            with self.subTest(break_ties=break_ties):
+                result = F.kwinners2d(x, self.duty_cycle, k=3,
+                                      boost_strength=0.0, local=False,
+                                      break_ties=break_ties)
 
-        num_correct = (result == expected).sum()
-        self.assertEqual(num_correct, result.reshape(-1).size()[0])
+                self.assertEqual(result.shape, expected.shape)
 
-        indices = ctx.saved_tensors[0].sort()[0]
-        expected_indices = torch.tensor([[3, 5, 10], [4, 5, 11]])
-        num_correct = (indices == expected_indices).sum()
-        self.assertEqual(num_correct, 6)
-
-        # Test that gradient values are in the right places, that their sum is
-        # equal, and that they have exactly the right number of nonzeros
-        out_grad, _, _, _ = F.KWinners2dGlobal.backward(ctx, self.gradient2)
-        out_grad = out_grad.reshape(2, -1)
-        in_grad = self.gradient2.reshape(2, -1)
-        self.assertEqual((out_grad == in_grad).sum(), 6)
-        self.assertEqual(len(out_grad.nonzero()), 6)
+                num_correct = (result == expected).sum()
+                self.assertEqual(num_correct, result.reshape(-1).size()[0])
 
     def test_k_winners2d_module_one(self):
         x = self.x2
@@ -230,26 +160,27 @@ class KWinners2DTest(unittest.TestCase):
         expected[1, 2, 1, 1] = x[1, 2, 1, 1]
 
         for break_ties in [True, False]:
-            kw = KWinners2d(
-                percent_on=0.333,
-                channels=3,
-                k_inference_factor=0.5,
-                boost_strength=1.0,
-                boost_strength_factor=0.5,
-                duty_cycle_period=1000,
-                local=False,
-                break_ties=break_ties,
-            )
+            with self.subTest(break_ties=break_ties):
+                kw = KWinners2d(
+                    percent_on=0.333,
+                    channels=3,
+                    k_inference_factor=0.5,
+                    boost_strength=1.0,
+                    boost_strength_factor=0.5,
+                    duty_cycle_period=1000,
+                    local=False,
+                    break_ties=break_ties,
+                )
 
-            result = kw(x)
-            self.assertEqual(result.shape, expected.shape)
+                result = kw(x)
+                self.assertEqual(result.shape, expected.shape)
 
-            num_correct = (result == expected).sum()
-            self.assertEqual(num_correct, result.reshape(-1).size()[0])
+                num_correct = (result == expected).sum()
+                self.assertEqual(num_correct, result.reshape(-1).size()[0])
 
-            new_duty = torch.tensor([1.5000, 1.5000, 1.0000]) / 4.0
-            diff = (kw.duty_cycle.reshape(-1) - new_duty).abs().sum()
-            self.assertLessEqual(diff, 0.001)
+                new_duty = torch.tensor([1.5000, 1.5000, 1.0000]) / 4.0
+                diff = (kw.duty_cycle.reshape(-1) - new_duty).abs().sum()
+                self.assertLessEqual(diff, 0.001)
 
     def test_k_winners2d_module_two(self):
         """
@@ -267,26 +198,27 @@ class KWinners2DTest(unittest.TestCase):
         expected[1, 2, 1, 1] = x[1, 2, 1, 1]
 
         for break_ties in [True, False]:
-            kw = KWinners2d(
-                percent_on=0.25,
-                channels=3,
-                k_inference_factor=0.5,
-                boost_strength=1.0,
-                boost_strength_factor=0.5,
-                duty_cycle_period=1000,
-                local=False,
-                break_ties=break_ties,
-            )
+            with self.subTest(break_ties=break_ties):
+                kw = KWinners2d(
+                    percent_on=0.25,
+                    channels=3,
+                    k_inference_factor=0.5,
+                    boost_strength=1.0,
+                    boost_strength_factor=0.5,
+                    duty_cycle_period=1000,
+                    local=False,
+                    break_ties=break_ties,
+                )
 
-            kw.train(mode=True)
-            result = kw(x)
-            result = kw(x)
-            result = kw(x)
-            result = kw(x)
-            result = kw(x)
-            result = kw(x)
+                kw.train(mode=True)
+                result = kw(x)
+                result = kw(x)
+                result = kw(x)
+                result = kw(x)
+                result = kw(x)
+                result = kw(x)
 
-            self.assertTrue(result.eq(expected).all())
+                self.assertTrue(result.eq(expected).all())
 
     def test_k_winners2d_relu(self):
         x = torch.zeros(2, 4, 2, 2)
@@ -304,20 +236,59 @@ class KWinners2DTest(unittest.TestCase):
         expected[0, 1, 0, 1] = 3
         expected[0, 2, 1, 0] = 3
 
-        kw = KWinners2d(
-            percent_on=0.25,
-            channels=4,
-            k_inference_factor=0.5,
-            boost_strength=1.0,
-            boost_strength_factor=0.5,
-            duty_cycle_period=1000,
-            local=False,
-            break_ties=False,
-            relu=True,
-        )
+        for break_ties in [True, False]:
+            with self.subTest(break_ties=break_ties):
+                kw = KWinners2d(
+                    percent_on=0.25,
+                    channels=4,
+                    k_inference_factor=0.5,
+                    boost_strength=1.0,
+                    boost_strength_factor=0.5,
+                    duty_cycle_period=1000,
+                    local=False,
+                    break_ties=break_ties,
+                    relu=True,
+                )
 
-        result = kw(x)
-        self.assertTrue(result.eq(expected).all())
+                result = kw(x)
+                self.assertTrue(result.eq(expected).all())
+
+    def test_k_winners2d_global_grad(self):
+        """
+        Test gradient
+        """
+        x = self.x2.clone().requires_grad_(True)
+        n, c, h, w = x.shape
+
+        grad = self.gradient2
+
+        expected = torch.zeros_like(x)
+        expected[0, 0, 1, 0] = grad[0, 0, 1, 0]
+        expected[0, 0, 1, 1] = grad[0, 0, 1, 1]
+        expected[0, 1, 0, 1] = grad[0, 1, 0, 1]
+        expected[0, 2, 1, 0] = grad[0, 2, 1, 0]
+
+        expected[1, 0, 0, 0] = grad[1, 0, 0, 0]
+        expected[1, 1, 0, 0] = grad[1, 1, 0, 0]
+        expected[1, 1, 0, 1] = grad[1, 1, 0, 1]
+        expected[1, 2, 1, 1] = grad[1, 2, 1, 1]
+
+        for break_ties in [True, False]:
+            with self.subTest(break_ties=break_ties):
+                kw = KWinners2d(
+                    percent_on=(1 / 3),
+                    channels=c,
+                    k_inference_factor=1.0,
+                    boost_strength=0.0,
+                    duty_cycle_period=1000,
+                    local=False,
+                    break_ties=break_ties,
+                )
+                kw.train(mode=True)
+                y = kw(x)
+                y.backward(grad)
+                torch.testing.assert_allclose(x.grad, expected)
+                x.grad.zero_()
 
 
 if __name__ == "__main__":

--- a/tests/k_winners2d_local_test.py
+++ b/tests/k_winners2d_local_test.py
@@ -54,23 +54,23 @@ class KWinner2dLocalTest(unittest.TestCase):
         expected[0, [2, 3], 1, 1] = x[0, [2, 3], 1, 1]
 
         for break_ties in [True, False]:
+            with self.subTest(break_ties=break_ties):
+                kw = KWinners2d(
+                    percent_on=0.5,  # k=2
+                    channels=c,
+                    k_inference_factor=1.0,
+                    boost_strength=0.0,
+                    duty_cycle_period=1000,
+                    local=True,
+                    break_ties=break_ties,
+                )
+                kw.train(mode=False)
 
-            kw = KWinners2d(
-                percent_on=0.5,  # k=2
-                channels=c,
-                k_inference_factor=1.0,
-                boost_strength=0.0,
-                duty_cycle_period=1000,
-                local=True,
-                break_ties=break_ties,
-            )
-            kw.train(mode=False)
+                result = kw(x)
+                self.assertEqual(result.shape, expected.shape)
 
-            result = kw(x)
-            self.assertEqual(result.shape, expected.shape)
-
-            num_correct = (result == expected).sum()
-            self.assertEqual(num_correct, result.reshape(-1).size()[0])
+                num_correct = (result == expected).sum()
+                self.assertEqual(num_correct, result.reshape(-1).size()[0])
 
     def test_k_winners2d_one_relu(self):
         """
@@ -84,23 +84,25 @@ class KWinner2dLocalTest(unittest.TestCase):
         expected[0, [1, 3], 0, 1] = x[0, [1, 3], 0, 1]
         expected[0, [2, 3], 1, 1] = x[0, [2, 3], 1, 1]
 
-        kw = KWinners2d(
-            percent_on=0.5,  # k=2
-            channels=c,
-            k_inference_factor=1.0,
-            boost_strength=0.0,
-            duty_cycle_period=1000,
-            local=True,
-            break_ties=False,
-            relu=True,
-        )
-        kw.train(mode=False)
+        for break_ties in [True, False]:
+            with self.subTest(break_ties=break_ties):
+                kw = KWinners2d(
+                    percent_on=0.5,  # k=2
+                    channels=c,
+                    k_inference_factor=1.0,
+                    boost_strength=0.0,
+                    duty_cycle_period=1000,
+                    local=True,
+                    break_ties=break_ties,
+                    relu=True,
+                )
+                kw.train(mode=False)
 
-        result = kw(x)
-        self.assertEqual(result.shape, expected.shape)
+                result = kw(x)
+                self.assertEqual(result.shape, expected.shape)
 
-        num_correct = (result == expected).sum()
-        self.assertEqual(num_correct, result.reshape(-1).size()[0])
+                num_correct = (result == expected).sum()
+                self.assertEqual(num_correct, result.reshape(-1).size()[0])
 
     def test_k_winners2d_two(self):
         """
@@ -122,22 +124,23 @@ class KWinner2dLocalTest(unittest.TestCase):
         expected[1, [0, 2], 1, 1] = x[1, [0, 2], 1, 1]
 
         for break_ties in [True, False]:
-            kw = KWinners2d(
-                percent_on=0.5,  # k=2
-                channels=c,
-                k_inference_factor=1.0,
-                boost_strength=0.0,
-                duty_cycle_period=1000,
-                local=True,
-                break_ties=break_ties,
-            )
-            kw.train(mode=False)
+            with self.subTest(break_ties=break_ties):
+                kw = KWinners2d(
+                    percent_on=0.5,  # k=2
+                    channels=c,
+                    k_inference_factor=1.0,
+                    boost_strength=0.0,
+                    duty_cycle_period=1000,
+                    local=True,
+                    break_ties=break_ties,
+                )
+                kw.train(mode=False)
 
-            result = kw(x)
-            self.assertEqual(result.shape, expected.shape)
+                result = kw(x)
+                self.assertEqual(result.shape, expected.shape)
 
-            num_correct = (result == expected).sum()
-            self.assertEqual(num_correct, result.reshape(-1).size()[0])
+                num_correct = (result == expected).sum()
+                self.assertEqual(num_correct, result.reshape(-1).size()[0])
 
     def test_k_winners2d_two_relu(self):
         """
@@ -156,23 +159,25 @@ class KWinner2dLocalTest(unittest.TestCase):
         expected[1, [1, 3], 0, 1] = x[1, [1, 3], 0, 1]
         expected[1, [0, 2], 1, 1] = x[1, [0, 2], 1, 1]
 
-        kw = KWinners2d(
-            percent_on=0.5,  # k=2
-            channels=c,
-            k_inference_factor=1.0,
-            boost_strength=0.0,
-            duty_cycle_period=1000,
-            local=True,
-            break_ties=False,
-            relu=True,
-        )
-        kw.train(mode=False)
+        for break_ties in [True, False]:
+            with self.subTest(break_ties=break_ties):
+                kw = KWinners2d(
+                    percent_on=0.5,  # k=2
+                    channels=c,
+                    k_inference_factor=1.0,
+                    boost_strength=0.0,
+                    duty_cycle_period=1000,
+                    local=True,
+                    break_ties=break_ties,
+                    relu=True,
+                )
+                kw.train(mode=False)
 
-        result = kw(x)
-        self.assertEqual(result.shape, expected.shape)
+                result = kw(x)
+                self.assertEqual(result.shape, expected.shape)
 
-        num_correct = (result == expected).sum()
-        self.assertEqual(num_correct, result.reshape(-1).size()[0])
+                num_correct = (result == expected).sum()
+                self.assertEqual(num_correct, result.reshape(-1).size()[0])
 
     def test_k_winners2d_train(self):
         """
@@ -195,31 +200,32 @@ class KWinner2dLocalTest(unittest.TestCase):
         expected[1, [0, 2], 1, 1] = x[1, [0, 2], 1, 1]
 
         for break_ties in [True, False]:
-            kw = KWinners2d(
-                percent_on=0.5,
-                channels=c,
-                boost_strength=1.0,
-                duty_cycle_period=10,
-                local=True,
-                break_ties=break_ties,
-            )
+            with self.subTest(break_ties=break_ties):
+                kw = KWinners2d(
+                    percent_on=0.5,
+                    channels=c,
+                    boost_strength=1.0,
+                    duty_cycle_period=10,
+                    local=True,
+                    break_ties=break_ties,
+                )
 
-            kw.train(mode=True)
+                kw.train(mode=True)
 
-            result = kw(x)
-            result = kw(x)
-            self.assertTrue(result.eq(expected).all())
+                result = kw(x)
+                result = kw(x)
+                self.assertTrue(result.eq(expected).all())
 
-            # Expectation due to boosting after the fourth training step
-            expected_boosted = expected.clone()
-            expected_boosted[0, [0, 1], 1, 1] = 0
-            expected_boosted[0, [0, 2], 1, 1] = x[0, [0, 2], 1, 1]
+                # Expectation due to boosting after the fourth training step
+                expected_boosted = expected.clone()
+                expected_boosted[0, [0, 1], 1, 1] = 0
+                expected_boosted[0, [0, 2], 1, 1] = x[0, [0, 2], 1, 1]
 
-            result = kw(x)
-            result = kw(x)
-            self.assertTrue(result.eq(expected_boosted).all())
+                result = kw(x)
+                result = kw(x)
+                self.assertTrue(result.eq(expected_boosted).all())
 
-    def test_k_winners2d_grad(self):
+    def test_k_winners2d_local_grad(self):
         """
         Test gradient
         """
@@ -238,23 +244,24 @@ class KWinner2dLocalTest(unittest.TestCase):
         expected[1, [0, 2], 1, 1] = grad[1, [0, 2], 1, 1]
 
         for break_ties in [True, False]:
+            with self.subTest(break_ties=break_ties):
 
-            kw = KWinners2d(
-                percent_on=0.5,  # k=2
-                channels=c,
-                k_inference_factor=1.0,
-                boost_strength=0.0,
-                duty_cycle_period=1000,
-                local=True,
-                break_ties=break_ties,
-            )
-            kw.train(mode=True)
-            y = kw(x)
+                kw = KWinners2d(
+                    percent_on=0.5,  # k=2
+                    channels=c,
+                    k_inference_factor=1.0,
+                    boost_strength=0.0,
+                    duty_cycle_period=1000,
+                    local=True,
+                    break_ties=break_ties,
+                )
+                kw.train(mode=True)
+                y = kw(x)
 
-            y.backward(grad)
+                y.backward(grad)
 
-            assert_allclose(x.grad, expected)
-            x.grad.zero_()
+                assert_allclose(x.grad, expected)
+                x.grad.zero_()
 
 
 if __name__ == "__main__":

--- a/tests/k_winners_test.py
+++ b/tests/k_winners_test.py
@@ -285,68 +285,70 @@ class KWinnersTest(unittest.TestCase):
         x = self.x2
         n = 6
 
-        kw = KWinners(
-            n,
-            percent_on=0.333,
-            k_inference_factor=1.5,
-            boost_strength=1.0,
-            boost_strength_factor=0.5,
-            duty_cycle_period=1000,
-        )
+        for break_ties in [True, False]:
+            kw = KWinners(
+                n,
+                percent_on=0.333,
+                k_inference_factor=1.5,
+                boost_strength=1.0,
+                boost_strength_factor=0.5,
+                duty_cycle_period=1000,
+                break_ties=break_ties,
+            )
 
-        # Test with mod.training = False.
-        kw.train(mode=False)
+            # Test with mod.training = False.
+            kw.train(mode=False)
 
-        # Expect 3 winners per batch (1.5 * 33% of 6 is 1 / 2 of 6)
-        expected = torch.zeros_like(x)
-        expected[0, 0] = x[0, 0]
-        expected[0, 2] = x[0, 2]
-        expected[0, 3] = x[0, 3]
-        expected[1, 0] = x[1, 0]
-        expected[1, 2] = x[1, 2]
-        expected[1, 3] = x[1, 3]
-        result = kw(x)
+            # Expect 3 winners per batch (1.5 * 33% of 6 is 1 / 2 of 6)
+            expected = torch.zeros_like(x)
+            expected[0, 0] = x[0, 0]
+            expected[0, 2] = x[0, 2]
+            expected[0, 3] = x[0, 3]
+            expected[1, 0] = x[1, 0]
+            expected[1, 2] = x[1, 2]
+            expected[1, 3] = x[1, 3]
+            result = kw(x)
 
-        self.assertEqual(result.shape, expected.shape)
-        self.assertTrue(result.eq(expected).all())
+            self.assertEqual(result.shape, expected.shape)
+            self.assertTrue(result.eq(expected).all())
 
-        # Run forward pass again while still not in training mode.
-        # Should give the same result as the duty cycles are not updated.
-        result = kw(x)
+            # Run forward pass again while still not in training mode.
+            # Should give the same result as the duty cycles are not updated.
+            result = kw(x)
 
-        self.assertEqual(result.shape, expected.shape)
-        self.assertTrue(result.eq(expected).all())
+            self.assertEqual(result.shape, expected.shape)
+            self.assertTrue(result.eq(expected).all())
 
-        # Test with mod.training = True
-        kw.train(mode=True)
+            # Test with mod.training = True
+            kw.train(mode=True)
 
-        # Expect 2 winners per batch (33% of 6)
-        expected = torch.zeros_like(x)
-        expected[0, 0] = x[0, 0]
-        expected[0, 3] = x[0, 3]
-        expected[1, 2] = x[1, 2]
-        expected[1, 3] = x[1, 3]
-        result = kw(x)
+            # Expect 2 winners per batch (33% of 6)
+            expected = torch.zeros_like(x)
+            expected[0, 0] = x[0, 0]
+            expected[0, 3] = x[0, 3]
+            expected[1, 2] = x[1, 2]
+            expected[1, 3] = x[1, 3]
+            result = kw(x)
 
-        self.assertEqual(result.shape, expected.shape)
-        self.assertTrue(result.eq(expected).all())
+            self.assertEqual(result.shape, expected.shape)
+            self.assertTrue(result.eq(expected).all())
 
-        # Test values of updated duty cycle.
-        new_duty = torch.tensor([1.0, 0, 1.0, 2.0, 0, 0]) / 2.0
+            # Test values of updated duty cycle.
+            new_duty = torch.tensor([1.0, 0, 1.0, 2.0, 0, 0]) / 2.0
 
-        self.assertTrue(kw.duty_cycle.eq(new_duty).all())
+            self.assertTrue(kw.duty_cycle.eq(new_duty).all())
 
-        # Test forward with updated duty cycle.
-        result = kw(x)
+            # Test forward with updated duty cycle.
+            result = kw(x)
 
-        expected = torch.zeros_like(x)
-        expected[0, 1] = x[0, 1]
-        expected[0, 5] = x[0, 5]
-        expected[1, 1] = x[1, 1]
-        expected[1, 5] = x[1, 5]
+            expected = torch.zeros_like(x)
+            expected[0, 1] = x[0, 1]
+            expected[0, 5] = x[0, 5]
+            expected[1, 1] = x[1, 1]
+            expected[1, 5] = x[1, 5]
 
-        self.assertEqual(result.shape, expected.shape)
-        self.assertTrue(result.eq(expected).all())
+            self.assertEqual(result.shape, expected.shape)
+            self.assertTrue(result.eq(expected).all())
 
     def test_k_winners_module_two(self):
         """
@@ -357,47 +359,50 @@ class KWinnersTest(unittest.TestCase):
         x = self.x2
         n = 6
 
-        expected = torch.zeros_like(x)
-        expected[0, 0] = x[0, 0]
-        expected[0, 5] = x[0, 5]
-        expected[1, 2] = x[1, 2]
-        expected[1, 3] = x[1, 3]
+        for break_ties in [True, False]:
 
-        kw = KWinners(
-            n,
-            percent_on=0.333,
-            k_inference_factor=1.5,
-            boost_strength=1.0,
-            boost_strength_factor=0.5,
-            duty_cycle_period=1000,
-        )
+            expected = torch.zeros_like(x)
+            expected[0, 0] = x[0, 0]
+            expected[0, 5] = x[0, 5]
+            expected[1, 2] = x[1, 2]
+            expected[1, 3] = x[1, 3]
 
-        kw.train(mode=True)
-        result = kw(x)
-        result = kw(x)
-        result = kw(x)
-        result = kw(x)
-        result = kw(x)
-        result = kw(x)
-        result = kw(x)
+            kw = KWinners(
+                n,
+                percent_on=0.333,
+                k_inference_factor=1.5,
+                boost_strength=1.0,
+                boost_strength_factor=0.5,
+                duty_cycle_period=1000,
+                break_ties=break_ties,
+            )
 
-        self.assertTrue(result.eq(expected).all())
+            kw.train(mode=True)
+            result = kw(x)
+            result = kw(x)
+            result = kw(x)
+            result = kw(x)
+            result = kw(x)
+            result = kw(x)
+            result = kw(x)
 
-        # Test with mod.training = False.
-        kw.train(mode=False)
-        result = kw(x)
-        expected = torch.zeros_like(x)
-        expected[0, 0] = x[0, 0]
-        expected[0, 1] = x[0, 1]
-        expected[0, 5] = x[0, 5]
-        expected[1, 2] = x[1, 2]
-        expected[1, 3] = x[1, 3]
-        expected[1, 4] = x[1, 4]
-        self.assertTrue(result.eq(expected).all())
+            self.assertTrue(result.eq(expected).all())
 
-    def test_tie_breaking(self):
+            # Test with mod.training = False.
+            kw.train(mode=False)
+            result = kw(x)
+            expected = torch.zeros_like(x)
+            expected[0, 0] = x[0, 0]
+            expected[0, 1] = x[0, 1]
+            expected[0, 5] = x[0, 5]
+            expected[1, 2] = x[1, 2]
+            expected[1, 3] = x[1, 3]
+            expected[1, 4] = x[1, 4]
+            self.assertTrue(result.eq(expected).all())
+
+    def test_tie_breaking_on(self):
         """
-        Test k-winners with tie-breaking
+        Test k-winners with ties. Tie-breaking enabled.
         """
         x = self.x2
         # Force tie breaking
@@ -425,6 +430,59 @@ class KWinnersTest(unittest.TestCase):
 
         result = F.KWinners.forward(ctx, x, self.duty_cycle2, k=3, boost_strength=1.0)
         self.assertTrue(result.eq(expected1).all() or result.eq(expected2).all())
+
+    def test_tie_breaking_off(self):
+        """
+        Test k-winners with ties. Tie-breaking disabled.
+        """
+        x = self.x2
+        # Force tie breaking
+        x[0, 5] = x[0, 1]
+
+        expected = torch.zeros_like(x)
+        expected[0, 0] = x[0, 0]
+        expected[0, 1] = x[0, 1]
+        expected[0, 3] = x[0, 3]
+        expected[0, 5] = x[0, 5]
+        expected[1, 1] = x[1, 1]
+        expected[1, 3] = x[1, 3]
+        expected[1, 5] = x[1, 5]
+
+        n = 6
+        kw = KWinners(n,
+                      percent_on=0.5,
+                      k_inference_factor=1.0,
+                      boost_strength=1.0,
+                      boost_strength_factor=0.5,
+                      duty_cycle_period=1000,
+                      break_ties=False)
+        kw.duty_cycle[:] = self.duty_cycle2
+
+        result = kw(x)
+        self.assertTrue(result.eq(expected).all())
+
+    def test_kwinners_relu(self):
+        n = 4
+        x = torch.tensor([
+            [-5, -2, -1, 2],
+            [-2, -1, 1, 2],
+            [-4, -3, -2, -1]
+        ], dtype=torch.float)
+        expected = torch.tensor([
+            [0, 0, 0, 2],
+            [0, 0, 1, 2],
+            [0, 0, 0, 0]
+        ], dtype=torch.float)
+
+        kw = KWinners(n,
+                      percent_on=0.5,
+                      k_inference_factor=1.0,
+                      boost_strength=1.0,
+                      break_ties=False,
+                      relu=True)
+
+        result = kw(x)
+        self.assertTrue(result.eq(expected).all())
 
 
 if __name__ == "__main__":

--- a/tests/k_winners_test.py
+++ b/tests/k_winners_test.py
@@ -421,7 +421,8 @@ class KWinnersTest(unittest.TestCase):
         expected2[1, 3] = x[1, 3]
         expected2[1, 5] = x[1, 5]
 
-        result = F.kwinners(x, self.duty_cycle2, k=3, boost_strength=1.0)
+        result = F.kwinners(x, self.duty_cycle2, k=3, boost_strength=1.0,
+                            break_ties=True)
         self.assertTrue(result.eq(expected1).all() or result.eq(expected2).all())
 
     def test_tie_breaking_off(self):


### PR DESCRIPTION
Using all three new capabilities, KWinners' runtime overhead in a resnet50 experiment drops to 53% of its current amount. Most of that speedup comes from `break_ties=False`.

I didn't need to create new `torch.autograd.Function` for this, it was possible to do with PyTorch's built-in functionality. In fact, we could implement the current functions (`KWinners2dLocal`, etc.) using PyTorch's built-in functionality (via `masked_fill`) and get rid of all of our custom `ctx` and `backward` logic. I implemented that alternate version, and the performance difference was negligible, so I didn't bother changing it.

Separately, I'm working on another PR that provides another small speedup.