### PR TITLE
Refactor SparseWeightsBase to inherit HasRezeroWeights

### DIFF
--- a/nupic/torch/modules/sparse_weights.py
+++ b/nupic/torch/modules/sparse_weights.py
@@ -33,9 +33,9 @@ def rezero_weights(m):
     Call using :meth:`torch.nn.Module.apply` after each epoch if required
     For example: ``m.apply(rezero_weights)``
 
-    :param m: SparseWeightsBase module
+    :param m: s/SparseWeightsBase/HasRezeroWeights module
     """
-    if isinstance(m, HasRezeroWeights):
+    if isinstance(m, HasRezeroWeights) and isinstance(m, nn.Module):
         if m.training:
             m.rezero_weights()
 

--- a/nupic/torch/modules/sparse_weights.py
+++ b/nupic/torch/modules/sparse_weights.py
@@ -35,7 +35,7 @@ def rezero_weights(m):
 
     :param m: SparseWeightsBase module
     """
-    if isinstance(m, SparseWeightsBase):
+    if isinstance(m, HasRezeroWeights):
         if m.training:
             m.rezero_weights()
 
@@ -59,7 +59,15 @@ def normalize_sparse_weights(m):
             nn.init.uniform_(m.module.bias, -bound, bound)
 
 
-class SparseWeightsBase(nn.Module, metaclass=abc.ABCMeta):
+class HasRezeroWeights(metaclass=abc.ABCMeta):
+
+    @abc.abstractmethod
+    def rezero_weights(self):
+        """Set the previously selected weights to zero."""
+        raise NotImplementedError
+
+
+class SparseWeightsBase(nn.Module, HasRezeroWeights):
     """
     Base class for the all Sparse Weights modules.
 
@@ -95,11 +103,6 @@ class SparseWeightsBase(nn.Module, metaclass=abc.ABCMeta):
             DeprecationWarning,
         )
         return 1.0 - self.sparsity
-
-    @abc.abstractmethod
-    def rezero_weights(self):
-        """Set the previously selected weights to zero."""
-        raise NotImplementedError
 
     @property
     def weight(self):

--- a/nupic/torch/modules/sparse_weights.py
+++ b/nupic/torch/modules/sparse_weights.py
@@ -33,11 +33,10 @@ def rezero_weights(m):
     Call using :meth:`torch.nn.Module.apply` after each epoch if required
     For example: ``m.apply(rezero_weights)``
 
-    :param m: s/SparseWeightsBase/HasRezeroWeights module
+    :param m: HasRezeroWeights module
     """
-    if isinstance(m, HasRezeroWeights) and isinstance(m, nn.Module):
-        if m.training:
-            m.rezero_weights()
+    if isinstance(m, HasRezeroWeights):
+        m.rezero_weights()
 
 
 def normalize_sparse_weights(m):


### PR DESCRIPTION
This refactor allows us to separate SparseWeights classes (those with a module and some amount of sparsity), and classes that have weights to rezero (custom modules that maintain parameters which need to be rezeroed).